### PR TITLE
build(ci): run workflow only when filters are satisfied

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,11 @@
 name: Build Shuvi
 on:
   push:
+    paths:
+      - 'patches/**'
   pull_request:
+    paths:
+      - 'patches/**'
     types:
       - opened
       - reopened


### PR DESCRIPTION
Configure a workflow to run based what file paths are changed when `push` and `pull_request` events are fired.